### PR TITLE
Allow to use helm-diff plugin together with helm-ssm

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "1.0.4"
+version: "1.0.5"
 usage: "AWS SSM parameter injection into Helm value files for git storage"
 description: |-
   AWS SSM parameter injection in Helm value files

--- a/ssm.sh
+++ b/ssm.sh
@@ -71,7 +71,7 @@ if [[ $# -eq 0 || "$cmd" == "help" || "$cmd" == "-h" || "$cmd" == "--help" ]]; t
 fi
 
 # if the command is not "install" or "upgrade", or just a single command (no value files is a given in this case), pass the args to the regular helm command
-if [[ $# -eq 1 || ( "$cmd" != "install" && "$cmd" != "upgrade" && "$cmd" != "template") ]]; then
+if [[ $# -eq 1 || ( "$cmd" != "install" && "$cmd" != "upgrade" && "$cmd" != "template" && "$cmd" != "diff" ) ]]; then
     set +e # disable fail-fast
     helm "$*"
     EXIT_CODE=$?


### PR DESCRIPTION
  Allow to use helm-diff plugin together with helm-ssm. As en example: "helm ssm diff upgrade argo-cd ./stable/argo-cd"